### PR TITLE
Add support for building snaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "linux": {
       "category": "Audio;AudioVideo",
       "target": [
+        "snap",
         "AppImage",
         "deb"
       ]


### PR DESCRIPTION
This tiny pull request adds support to build cumulonimbus as a snap.

cumulonimbus is already [available](https://snapcraft.io/cumulonimbus/) in the snap store via the yaml in the [snapcrafter](https://github.com/snapcrafters/cumulonimbus) which consumes the deb and pushes that into a snap. This PR takes a pleasant approach of using the built-in snap output of electron-builder.

If the PR is accepted, we can transfer ownership of the cumulonimbus snap to you, the upstream developer. Once done you could automatically upload the built snaps to the store using `snapcraft push`. With multiple channels in the store, you could have adventurous users get automatic updates to your latest pre-release builds of cumulonimbus, and provide feedback based on the latest build.

If accepted, I'm happy to walk you through the next steps. 